### PR TITLE
fix: update dark theme handling in globals.css

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 @theme inline {
   --color-background: var(--background);
@@ -78,7 +78,7 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-.dark {
+[data-theme="dark"] {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);


### PR DESCRIPTION
- Changed custom variant for dark theme to use `&:where([data-theme=dark], [data-theme=dark] *)` for better specificity.
- Updated dark class selector to `[data-theme="dark"]` for consistency with the new approach.